### PR TITLE
feat: temporarily hide Feed/Activity tab

### DIFF
--- a/client/src/components/modules/tabs.tsx
+++ b/client/src/components/modules/tabs.tsx
@@ -65,9 +65,8 @@ export interface ArcadeTabsProps
 }
 
 export const ArcadeTabs = ({
-  defaultValue = "activity",
+  defaultValue = "leaderboard",
   order = [
-    "activity",
     "leaderboard",
     "about",
     "metrics",

--- a/client/src/components/pages/game.tsx
+++ b/client/src/components/pages/game.tsx
@@ -36,12 +36,12 @@ export function GamePage() {
   );
 
   const order: TabValue[] = useMemo(() => {
-    if (!game) return ["activity", "leaderboard", "marketplace"];
-    return ["activity", "leaderboard", "marketplace", "guilds", "about"];
+    if (!game) return ["leaderboard", "marketplace"];
+    return ["leaderboard", "marketplace", "guilds", "about"];
   }, [game]);
 
   const defaultValue = useMemo(() => {
-    if (!order.includes(tab as TabValue)) return "activity";
+    if (!order.includes(tab as TabValue)) return "leaderboard";
     return tab;
   }, [tab, order]);
 
@@ -96,12 +96,13 @@ export function GamePage() {
           className="flex justify-center gap-8 w-full h-full overflow-y-scroll"
           style={{ scrollbarWidth: "none" }}
         >
+          {/* Temporarily hidden Feed/Activity tab
           <TabsContent
             className="p-0 px-3 lg:px-6 mt-0 grow w-full"
             value="activity"
           >
             <DiscoverScene />
-          </TabsContent>
+          </TabsContent> */}
           <TabsContent
             className="p-0 px-3 lg:px-6 mt-0 grow w-full"
             value="leaderboard"

--- a/client/src/components/pages/market.tsx
+++ b/client/src/components/pages/market.tsx
@@ -18,7 +18,7 @@ import { joinPaths } from "@/helpers";
 import arcade from "@/assets/arcade-logo.png";
 import { useCollection } from "@/hooks/market-collections";
 
-const TABS_ORDER = ["activity", "items", "holders"] as TabValue[];
+const TABS_ORDER = ["items", "holders"] as TabValue[];
 
 export function MarketPage() {
   const { game, edition, tab, collection: collectionAddress } = useProject();
@@ -103,12 +103,13 @@ export function MarketPage() {
           className="flex justify-center gap-8 w-full h-full overflow-y-scroll"
           style={{ scrollbarWidth: "none" }}
         >
+          {/* Temporarily hidden Feed/Activity tab
           <TabsContent
             className="p-0 px-3 lg:px-6 mt-0 grow w-full"
             value="activity"
           >
             <TraceabilityScene />
-          </TabsContent>
+          </TabsContent> */}
           <TabsContent className="p-0 mt-0 grow w-full" value="items">
             <ItemsScene />
           </TabsContent>

--- a/client/src/components/pages/player.tsx
+++ b/client/src/components/pages/player.tsx
@@ -26,7 +26,7 @@ import { toast } from "sonner";
 import { useProject } from "@/hooks/project";
 import { joinPaths } from "@/helpers";
 
-const TABS_ORDER = ["inventory", "achievements", "activity"] as TabValue[];
+const TABS_ORDER = ["inventory", "achievements"] as TabValue[];
 
 export function PlayerPage() {
   const { address, isSelf, self } = useAddress();
@@ -245,12 +245,13 @@ export function PlayerPage() {
           >
             <AchievementScene />
           </TabsContent>
+          {/* Temporarily hidden Feed/Activity tab
           <TabsContent
             className="p-0 px-3 lg:px-6 mt-0 grow w-full h-full"
             value="activity"
           >
             <ActivityScene />
-          </TabsContent>
+          </TabsContent> */}
         </div>
       </ArcadeTabs>
     </>


### PR DESCRIPTION
## Summary
- Temporarily removes the Feed/Activity tab from the arcade interface to simplify navigation
- The code is commented out rather than deleted for easy restoration when needed

## Changes
- Removed "activity" from tab orders in game, player, and market pages
- Changed default tab from "activity" to "leaderboard" across all pages
- Commented out Activity tab content sections to preserve the code

## Test plan
- [x] Verify the Activity tab no longer appears in the main game navigation
- [x] Verify the Activity tab no longer appears in player profiles
- [x] Verify the Activity tab no longer appears in the marketplace
- [x] Confirm default tab switches to "leaderboard" when navigating to pages
- [x] Check that all other tabs continue to function normally

🤖 Generated with [Claude Code](https://claude.ai/code)