### PR TITLE
fix: update number of columns in market place scene

### DIFF
--- a/client/src/components/items/index.tsx
+++ b/client/src/components/items/index.tsx
@@ -266,7 +266,7 @@ export function Items({ edition, collectionAddress }: { edition: EditionModel, c
           }}
         >
           {virtualizer.getVirtualItems().map((virtualRow) => {
-            const startIndex = virtualRow.index * 3;
+            const startIndex = virtualRow.index * 4;
             const endIndex = Math.min(
               startIndex + 4,
               searchFilteredTokens.length


### PR DESCRIPTION
This increases the number of default columns in desktop and monitor view to be 4 (initially 3)

Bug link: https://discord.com/channels/954866867376357397/1360734731854942279/1418601991277514894
linear ticket: https://linear.app/cartridge/issue/C7E-963/modify-grid-columns-to-accommodate-the-new-increased-width-of-the